### PR TITLE
fix: handle escape character correctly

### DIFF
--- a/src/compressor/string.ts
+++ b/src/compressor/string.ts
@@ -1,4 +1,4 @@
-import { DATE_REGEX, REF_STRING_TOKEN, REGEX_STRING_TOKEN, ESCAPED_STRING_TOKEN, STRING_TOKEN, REFERENCE_HEADER_LENGTH, UNREFERENCED_STRING_TOKEN, REGEX_UNREFERENCED_STRING_TOKEN, ESCAPED_UNREFERENCED_STRING_TOKEN, STRING_IDENT_PREFIX } from "../constants";
+import { DATE_REGEX, REF_STRING_TOKEN, REGEX_STRING_TOKEN, ESCAPED_STRING_TOKEN, STRING_TOKEN, REFERENCE_HEADER_LENGTH, UNREFERENCED_STRING_TOKEN, REGEX_UNREFERENCED_STRING_TOKEN, ESCAPED_UNREFERENCED_STRING_TOKEN, STRING_IDENT_PREFIX, ESCAPE_CHARACTER, REGEX_ESCAPE_CHARACTER } from "../constants";
 import { Context, InvertedIndex, CompressOptions, Compressors } from "./common";
 import { ZipsonWriter } from "./writer";
 import { compressInteger } from "../util";
@@ -27,13 +27,13 @@ export function compressString(
     writer.write(`${REF_STRING_TOKEN}${foundRef}`)
   } else {
     const ref = compressInteger(invertedIndex.stringCount);
-    const newRef = `${STRING_TOKEN}${obj.replace(REGEX_STRING_TOKEN, ESCAPED_STRING_TOKEN)}${STRING_TOKEN}`;
+    const newRef = `${STRING_TOKEN}${obj.replace(REGEX_ESCAPE_CHARACTER, ESCAPE_CHARACTER + ESCAPE_CHARACTER).replace(REGEX_STRING_TOKEN, ESCAPED_STRING_TOKEN)}${STRING_TOKEN}`;
     if(ref.length + REFERENCE_HEADER_LENGTH + 1 < newRef.length) {
       invertedIndex.stringMap[stringIdent] = ref;
       invertedIndex.stringCount++;
       writer.write(newRef)
     } else {
-      writer.write(`${UNREFERENCED_STRING_TOKEN}${obj.replace(REGEX_UNREFERENCED_STRING_TOKEN, ESCAPED_UNREFERENCED_STRING_TOKEN)}${UNREFERENCED_STRING_TOKEN}`);
+      writer.write(`${UNREFERENCED_STRING_TOKEN}${obj.replace(REGEX_ESCAPE_CHARACTER, ESCAPE_CHARACTER + ESCAPE_CHARACTER).replace(REGEX_UNREFERENCED_STRING_TOKEN, ESCAPED_UNREFERENCED_STRING_TOKEN)}${UNREFERENCED_STRING_TOKEN}`);
     }
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -43,6 +43,8 @@ export const ESCAPED_UNREFERENCED_STRING_TOKEN = `${ESCAPE_CHARACTER}${UNREFEREN
 /**
  * Regex lookups
  */
+export const REGEX_ESCAPE_CHARACTER = new RegExp(ESCAPE_CHARACTER.replace("\\", "\\\\"), 'g');
+export const REGEX_ESCAPED_ESCAPE_CHARACTER = new RegExp(ESCAPE_CHARACTER.replace("\\", "\\\\") + ESCAPE_CHARACTER.replace("\\", "\\\\"), 'g');
 export const REGEX_STRING_TOKEN = new RegExp(STRING_TOKEN, 'g');
 export const REGEX_ESCAPED_STRING_TOKEN = new RegExp(ESCAPE_CHARACTER + ESCAPED_STRING_TOKEN, 'g');
 export const REGEX_UNREFERENCED_STRING_TOKEN = new RegExp(UNREFERENCED_STRING_TOKEN, 'g');

--- a/test/full/array-homogenous.ts
+++ b/test/full/array-homogenous.ts
@@ -146,6 +146,18 @@ describe('array-homogenous', function() {
     testPackUnpackHomogeneousArray('"aoasdfjalisruhgals"iuhfdlsajdlifuashrlifuhsaildjfsalkhglasurflasjdfklsandfasurliausnlc"', MANY);
   });
 
+  it('stringEscapeCharacterOne', function() {
+    testPackUnpackHomogeneousArray('aoasdfjalisruhgals\\iuhfdlsajdlifuashrlifuhsaildjfsalkhglasurflasjdfklsandfasurliausnlc', MANY);
+  });
+
+  it('stringEscapeCharacterMultiple', function() {
+    testPackUnpackHomogeneousArray('aoasdfjalisruhgals\\\\iuhfdlsajdlifuashrlifuhsaildjfsalkhglas\\urflasjdfklsandfasurliausnlc', MANY);
+  });
+
+  it('stringEscapeCharacterEnd', function() {
+    testPackUnpackHomogeneousArray('aoasdfjalisruhgals\\\\iuhfdlsajdlifuashrlifuhsaildjfsalkhglas\\urflasjdfklsandfasurliausnlc\\', MANY);
+  });
+
   it('objectOne', function() {
     testPackUnpackHomogeneousArray({ x: 123 }, ONE);
   });


### PR DESCRIPTION
zipson currently has an issue when there is an escape character (backslash) at the end of a string which will be compressed, for example within an array. The array can be stringified but not parsed again.

I fixed the behavior by:

- compression: handle escape character correctly by escaping them with two escape characters (one backslash will be converted to two backslash within the stringified zipson output
- decompression: when determining the end of a string, check how many escape characters the token has. only treat it as escaped, if it has an odd number of escape characters. later, also replace double escapes with single escape character again

I also added some tests for this. The test stringEscapeCharacterEnd will fail without my changes!

The constants sections looks a bit strange, but the problem is you cannot create a regex from a string containing a single backslash. I had the option of defining the regex completely independent from ESCAPE_CHARACTER, but i decided to use it and replace single backslash with double. This behavior should also work if ESCAPE_CHARACTER would be something different than backslash.